### PR TITLE
プロジェクト設定ファイルとドキュメントの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/docs/directory.md
+++ b/docs/directory.md
@@ -1,0 +1,58 @@
+# ディレクトリ構成
+
+このプロジェクトは以下のディレクトリ構造で構成されています。
+
+```
+.
+├── .cursor/                   # Cursor IDE の設定ファイル
+├── .git/                      # Gitリポジトリ情報
+├── client/                    # フロントエンドのソースコード
+│   ├── assets/                # 静的アセット
+│   │   └── openai-logomark.svg # OpenAIのロゴ
+│   ├── components/            # Reactコンポーネント
+│   │   ├── App.jsx            # メインアプリケーションコンポーネント
+│   │   ├── Button.jsx         # ボタンコンポーネント
+│   │   ├── EventLog.jsx       # イベントログ表示コンポーネント
+│   │   ├── SessionControls.jsx # セッション制御コンポーネント
+│   │   └── ToolPanel.jsx      # ツールパネルコンポーネント
+│   ├── pages/                 # ページコンポーネント
+│   │   └── index.jsx          # メインページ
+│   ├── base.css               # 基本スタイル定義
+│   ├── entry-client.jsx       # クライアントエントリーポイント
+│   ├── entry-server.jsx       # サーバーサイドレンダリングエントリーポイント
+│   ├── index.html             # HTMLテンプレート
+│   └── index.js               # メインJavaScriptファイル
+├── coverage/                  # テストカバレッジレポート
+├── docs/                      # プロジェクトドキュメント
+│   ├── technology-stack.md    # 技術スタック情報
+│   └── directory.md           # ディレクトリ構造情報
+├── node_modules/              # Node.js 依存パッケージ
+├── .env                       # 環境変数（非公開）
+├── .env.example               # 環境変数のサンプル
+├── .gitignore                 # Gitの無視ファイル設定
+├── .prettierrc                # Prettier設定
+├── LICENSE                    # ライセンス情報（MIT）
+├── README.md                  # プロジェクト概要説明
+├── package-lock.json          # パッケージのバージョン固定ファイル
+├── package.json               # プロジェクト設定とスクリプト
+├── postcss.config.cjs         # PostCSS設定
+├── server.js                  # Express サーバー
+├── tailwind.config.js         # Tailwind CSS 設定
+└── vite.config.js             # Vite ビルド設定
+```
+
+## 主要コンポーネント
+
+### バックエンド
+- `server.js`: Express サーバーの設定と実行コード。OpenAI Realtime API とのインテグレーションを処理。
+
+### フロントエンド
+- `client/components/App.jsx`: メインアプリケーションの実装。WebRTC接続と状態管理。
+- `client/components/EventLog.jsx`: 送受信されたイベントをログ表示するコンポーネント。
+- `client/components/SessionControls.jsx`: セッション開始/停止などのコントロール。
+- `client/components/ToolPanel.jsx`: 利用可能なツールを提供するパネル。
+
+### ビルド設定
+- `vite.config.js`: Vite ビルドツールの設定。
+- `postcss.config.cjs`: PostCSS の処理設定。
+- `tailwind.config.js`: Tailwind CSS のカスタマイズ設定。 

--- a/docs/technology-stack.md
+++ b/docs/technology-stack.md
@@ -1,0 +1,37 @@
+# 技術スタック
+
+このプロジェクトは OpenAI の Realtime API を WebRTC を使用してデモンストレーションするアプリケーションです。
+
+## フロントエンド
+- **React**: ^18.2.0
+- **React DOM**: ^18.2.0
+- **React Router DOM**: ^6.20.0
+- **React Feather**: ^2.0.10（アイコンライブラリ）
+- **History**: ^5.3.0（履歴管理）
+
+## バックエンド
+- **Node.js**
+- **Express**: ^4.21.2（Webサーバーフレームワーク）
+- **dotenv**: ^16.4.7（環境変数管理）
+
+## ビルドツール
+- **Vite**: ^5.0.2（フロントエンドビルドツール）
+- **@vitejs/plugin-react**: ^4.3.4（Vite用Reactプラグイン）
+
+## スタイリング
+- **TailwindCSS**: ^3.4.1（ユーティリティファーストCSSフレームワーク）
+- **PostCSS**: ^8.4.31（CSSプロセッサー）
+- **PostCSS Nesting**: ^12.0.2（CSSネスト機能）
+- **PostCSS Preset Env**: ^7.7.1（モダンなCSS機能のサポート）
+
+## API
+- **OpenAI Realtime API**（WebRTC経由）
+
+## 開発環境
+- **ESLint**（コード品質管理）
+- **Prettier**: .prettierrc設定ファイルによる整形ルール
+
+## デプロイメント
+- 開発モード: `npm run dev`
+- 本番モード: `npm start`
+- ビルド: `npm run build`（クライアントとサーバーの両方をビルド） 


### PR DESCRIPTION
## 概要
- .gitignoreファイルを追加して、node_modulesと.envファイルを無視するように設定
- docs/directory.mdを追加してプロジェクトのディレクトリ構造を文書化
- docs/technology-stack.mdを追加してプロジェクトの技術スタックを文書化

Issue無し
